### PR TITLE
Add partition tooltip to essentia cells

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile("com.github.GTNewHorizons:NotEnoughItems:2.2.15-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.4:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.1.5:dev")
-    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-86-GTNH:dev")
+    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-112-GTNH:dev")
 
     compile("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
 

--- a/src/main/java/thaumicenergistics/common/registries/ThEStrings.java
+++ b/src/main/java/thaumicenergistics/common/registries/ThEStrings.java
@@ -60,6 +60,7 @@ public enum ThEStrings
 		Tooltip_ItemStackDetails ("tooltip.itemstack.details", false),
 		Tooltip_CellBytes ("tooltip.essentia.cell.bytes", false),
 		Tooltip_CellTypes ("tooltip.essentia.cell.types", false),
+		Tooltip_CellContains ("tooltip.essentia.cell.contains", false),
 		Tooltip_ArcaneAssemblerHasVis ("tooltip.arcane.assembler.hasVis", false),
 
 		// Button Tooltips

--- a/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
@@ -48,7 +48,8 @@ thaumicenergistics.item.focus.aewrench.disabled.name=Wand Focus: AE Wrench - Wre
 thaumicenergistics.item.golem.wifi.backpack.name=Wireless Golem Backpack
 
 #Tooltips
-thaumicenergistics.tooltip.itemstack.details=Hold §eshift§f for details.
+thaumicenergistics.tooltip.itemstack.details=Hold §eCTRL§f for details.
+thaumicenergistics.tooltip.essentia.cell.contains=Contains
 thaumicenergistics.tooltip.essentia.cell.bytes=%d of %d bytes used.
 thaumicenergistics.tooltip.essentia.cell.types=%d of %d essentia types stored.
 thaumicenergistics.tooltip.button.void=Allow Void?


### PR DESCRIPTION
Just like in [AE2FC](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/27), adding a partition tooltip.

This time, there was already binded content tooltip when holding SHIFT, so to keep it consistent with AE2FC and AE2, I've changed the content to CTRL, and added filter to SHIFT.

When nothing is held:
![image](https://user-images.githubusercontent.com/22837945/194807922-ea7ff6ae-88d6-47ca-9f59-09340abc4ed7.png)

When SHIFT is held: 
![image](https://user-images.githubusercontent.com/22837945/194807957-828b2fa3-9d62-4df9-8fe8-0e4af19dee78.png)

When CTRL is held:
![image](https://user-images.githubusercontent.com/22837945/194807988-ca061118-8915-4577-b5e4-ce1546925564.png)

When both keys are held:
![image](https://user-images.githubusercontent.com/22837945/194808004-6b4bd22a-db52-4851-b862-4409138a45b3.png)
