### PR TITLE
Allow Arcane Assembler parallel

### DIFF
--- a/src/main/java/thaumicenergistics/common/integration/tc/ArcaneCraftingPattern.java
+++ b/src/main/java/thaumicenergistics/common/integration/tc/ArcaneCraftingPattern.java
@@ -1,6 +1,8 @@
 package thaumicenergistics.common.integration.tc;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import appeng.api.AEApi;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
@@ -101,6 +103,9 @@ public class ArcaneCraftingPattern
 
 		// Set validity
 		this.setPatternValidity( ( this.aspects.size() > 0 ) && ( this.result != null ) && hasAtLeastOneValidInput );
+
+		// Ensure AE result and ingredients are populated
+		this.setupAEResults();
 	}
 
 	/**
@@ -118,6 +123,9 @@ public class ArcaneCraftingPattern
 
 		// Read the data
 		this.readFromNBT( data );
+
+		// Ensure AE result and ingredients are populated
+		this.setupAEResults();
 	}
 
 	/**
@@ -785,6 +793,30 @@ public class ArcaneCraftingPattern
 		data.setTag( ArcaneCraftingPattern.NBTKEY_RESULT, outData );
 
 		return data;
+	}
+
+	// Custom equality so AE may see the same recipe as the same pattern
+	// Allows AE to parallel if multiple assemblers with this recipe are available
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ArcaneCraftingPattern that = (ArcaneCraftingPattern) o;
+
+		if (isValid != that.isValid) return false;
+		if (!Objects.equals(result, that.result)) return false;
+		if (!Arrays.equals(ingredientsAE, that.ingredientsAE)) return false;
+		return Arrays.equals(allResults, that.allResults);
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = result != null ? result.hashCode() : 0;
+		hash = 31 * hash + Arrays.hashCode(ingredientsAE);
+		hash = 31 * hash + Arrays.hashCode(allResults);
+		hash = 31 * hash + (isValid ? 1 : 0);
+		return hash;
 	}
 
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10504

Adds custom equality and hashing to ArcaneCraftingPatterns so that AE does not create additional crafting methods for the same pattern and instead views two patterns with the same recipe as the same with different providers.

https://user-images.githubusercontent.com/73182109/196304410-1f99ef59-b5b7-4d3e-8439-7e1b865363fc.mp4

