### PR TITLE
Expand IAspectSlotPart API

### DIFF
--- a/src/main/java/thaumicenergistics/common/network/IAspectSlotPart.java
+++ b/src/main/java/thaumicenergistics/common/network/IAspectSlotPart.java
@@ -11,10 +11,14 @@ import thaumcraft.api.aspects.Aspect;
  *
  */
 public interface IAspectSlotPart {
-    int[] getAvailableAspectSlots();
+    default int[] getAvailableAspectSlots() {
+        return new int[0];
+    }
 
     @Nullable
-    Aspect getAspect(int index);
+    default Aspect getAspect(int index) {
+        return null;
+    }
 
     void setAspect(int index, Aspect aspect, EntityPlayer player);
 }

--- a/src/main/java/thaumicenergistics/common/network/IAspectSlotPart.java
+++ b/src/main/java/thaumicenergistics/common/network/IAspectSlotPart.java
@@ -1,5 +1,6 @@
 package thaumicenergistics.common.network;
 
+import javax.annotation.Nullable;
 import net.minecraft.entity.player.EntityPlayer;
 import thaumcraft.api.aspects.Aspect;
 
@@ -10,5 +11,10 @@ import thaumcraft.api.aspects.Aspect;
  *
  */
 public interface IAspectSlotPart {
+    int[] getAvailableAspectSlots();
+
+    @Nullable
+    Aspect getAspect(int index);
+
     void setAspect(int index, Aspect aspect, EntityPlayer player);
 }

--- a/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
@@ -566,6 +566,22 @@ public class PartEssentiaLevelEmitter extends ThEPartBase implements IAspectSlot
     }
 
     /**
+     * Gets valid values for the index parameter of getAspect and setAspect
+     */
+    @Override
+    public int[] getAvailableAspectSlots() {
+        return new int[1];
+    }
+
+    /**
+     * Gets the aspect we are filtering
+     */
+    @Override
+    public Aspect getAspect(final int index) {
+        return this.trackedAspect;
+    }
+
+    /**
      * Set's the aspect we are filtering
      */
     @Override

--- a/src/main/java/thaumicenergistics/common/parts/PartEssentiaStorageBus.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartEssentiaStorageBus.java
@@ -495,6 +495,27 @@ public class PartEssentiaStorageBus extends ThEPartBase
     }
 
     /**
+     * Gets valid values for the index parameter of getAspect and setAspect
+     */
+    @Override
+    public int[] getAvailableAspectSlots() {
+        int[] available = new int[FILTER_SIZE];
+        for (int i = 0; i < FILTER_SIZE; i++) {
+            available[i] = i;
+        }
+
+        return available;
+    }
+
+    /**
+     * Gets the aspect from one of the filters.
+     */
+    @Override
+    public Aspect getAspect(final int index) {
+        return this.filteredAspects.get(index);
+    }
+
+    /**
      * Sets one of the filters.
      */
     @Override

--- a/src/main/java/thaumicenergistics/common/parts/ThEPartEssentiaIOBus_Base.java
+++ b/src/main/java/thaumicenergistics/common/parts/ThEPartEssentiaIOBus_Base.java
@@ -525,6 +525,22 @@ public abstract class ThEPartEssentiaIOBus_Base extends ThEPartBase
         this.markForSave();
     }
 
+    /**
+     * Gets valid values for the index parameter of getAspect and setAspect
+     */
+    @Override
+    public final int[] getAvailableAspectSlots() {
+        return availableFilterSlots.clone();
+    }
+
+    /**
+     * Gets the aspect from one of the filters.
+     */
+    @Override
+    public final Aspect getAspect(final int index) {
+        return this.filteredAspects.get(index);
+    }
+
     @Override
     public final void setAspect(final int index, final Aspect aspect, final EntityPlayer player) {
         // Set the filter


### PR DESCRIPTION
Not used in the mod itself, but for use in other mods that interact with this one (e.g. OpenComputers). Two new functions were added for `IAspectSlotPart`:

- `getAvailableAspectSlots` returns an array so that consumers know which `index` values are valid for calls to `getAspect` and `setAspect`. This is particularly important for the import/export busses as the available slots (defined by number of capacity cards inserted into the bus) do not go in order -- slot 4 is always available, the first capacity card adds slots 1, 3, 5, and 7, and the final capacity card adds 0, 2, 6, and 8. To avoid shenanigans with consumers modifying this array, a clone is returned rather than the original array.
- `getAspect` returns the `Aspect` that a particular slot is filtering for, or `null` if there is no filter for that slot.