### PR TITLE
Buff Essentia IO busses to 4 (from 2) upgrade cards

### DIFF
--- a/src/main/java/thaumicenergistics/common/parts/AEPartsEnum.java
+++ b/src/main/java/thaumicenergistics/common/parts/AEPartsEnum.java
@@ -26,7 +26,7 @@ public enum AEPartsEnum {
     @SuppressWarnings("unchecked")
     EssentiaImportBus(ThEStrings.Part_EssentiaImportBus, PartEssentiaImportBus.class,
             ThaumicEnergistics.MOD_ID + ".group.essentia.transport", generatePair(Upgrades.CAPACITY, 2),
-            generatePair(Upgrades.REDSTONE, 1), generatePair(Upgrades.SPEED, 2)),
+            generatePair(Upgrades.REDSTONE, 1), generatePair(Upgrades.SPEED, 4)),
 
     EssentiaLevelEmitter(ThEStrings.Part_EssentiaLevelEmitter, PartEssentiaLevelEmitter.class),
 
@@ -37,7 +37,7 @@ public enum AEPartsEnum {
     @SuppressWarnings("unchecked")
     EssentiaExportBus(ThEStrings.Part_EssentiaExportBus, PartEssentiaExportBus.class,
             ThaumicEnergistics.MOD_ID + ".group.essentia.transport", generatePair(Upgrades.CAPACITY, 2),
-            generatePair(Upgrades.REDSTONE, 1), generatePair(Upgrades.SPEED, 2), generatePair(Upgrades.CRAFTING, 1)),
+            generatePair(Upgrades.REDSTONE, 1), generatePair(Upgrades.SPEED, 4), generatePair(Upgrades.CRAFTING, 1)),
 
     EssentiaTerminal(ThEStrings.Part_EssentiaTerminal, PartEssentiaTerminal.class),
 

--- a/src/main/java/thaumicenergistics/common/parts/ThEPartEssentiaIOBus_Base.java
+++ b/src/main/java/thaumicenergistics/common/parts/ThEPartEssentiaIOBus_Base.java
@@ -340,7 +340,7 @@ public abstract class ThEPartEssentiaIOBus_Base extends ThEPartBase
      */
     @Override
     public double getIdlePowerUsage() {
-        return ThEPartEssentiaIOBus_Base.IDLE_POWER_DRAIN;
+        return ThEPartEssentiaIOBus_Base.IDLE_POWER_DRAIN * (1 << upgradeSpeedCount);
     }
 
     /**


### PR DESCRIPTION
Also increases idle power usage by an exponential amount

Formula is 4 + (upgradeCount * 8) essentia/tick

New Idle Power is 0.7 * (2^upgradeCount)

close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13928