### PR TITLE
Fix bad metadata

### DIFF
--- a/src/main/java/thaumicenergistics/api/IThEParts.java
+++ b/src/main/java/thaumicenergistics/api/IThEParts.java
@@ -63,4 +63,10 @@ public abstract class IThEParts {
      */
     @Nonnull
     public IThEItemDescription Essentia_ConversionMonitor;
+
+    /**
+     * Creative vis relay interface.
+     */
+    @Nonnull
+    public IThEItemDescription CreativeVisRelay_Interface;
 }

--- a/src/main/java/thaumicenergistics/common/parts/AEPartsEnum.java
+++ b/src/main/java/thaumicenergistics/common/parts/AEPartsEnum.java
@@ -45,11 +45,11 @@ public enum AEPartsEnum {
 
     VisInterface(ThEStrings.Part_VisRelayInterface, PartVisInterface.class),
 
-    CreativeVisInterface(ThEStrings.Part_CreativeVisRelayInterface, PartCreativeVisInterface.class),
-
     EssentiaStorageMonitor(ThEStrings.Part_EssentiaStorageMonitor, PartEssentiaStorageMonitor.class),
 
-    EssentiaConversionMonitor(ThEStrings.Part_EssentiaConversionMonitor, PartEssentiaConversionMonitor.class);
+    EssentiaConversionMonitor(ThEStrings.Part_EssentiaConversionMonitor, PartEssentiaConversionMonitor.class),
+
+    CreativeVisInterface(ThEStrings.Part_CreativeVisRelayInterface, PartCreativeVisInterface.class);
 
     /**
      * Cached enum values

--- a/src/main/java/thaumicenergistics/common/parts/PartCreativeVisInterface.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartCreativeVisInterface.java
@@ -4,6 +4,10 @@ import thaumcraft.api.aspects.Aspect;
 
 public class PartCreativeVisInterface extends PartVisInterface {
 
+    public PartCreativeVisInterface() {
+        super(AEPartsEnum.CreativeVisInterface);
+    }
+
     @Override
     protected int consumeVisFromVisNetwork(Aspect digiVisAspect, int amount) {
         return amount;

--- a/src/main/java/thaumicenergistics/common/parts/PartVisInterface.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartVisInterface.java
@@ -114,6 +114,12 @@ public class PartVisInterface extends ThEPartBase implements IGridTickable, IDig
         this.UID = System.currentTimeMillis() ^ this.hashCode();
     }
 
+    public PartVisInterface(AEPartsEnum part) {
+        super(part);
+
+        this.UID = System.currentTimeMillis() ^ this.hashCode();
+    }
+
     /**
      * Requests that the interface drain vis from the relay
      *

--- a/src/main/java/thaumicenergistics/implementaion/ThEParts.java
+++ b/src/main/java/thaumicenergistics/implementaion/ThEParts.java
@@ -21,5 +21,6 @@ class ThEParts extends IThEParts {
         this.VisRelay_Interface = new ThEItemDescription(AEPartsEnum.VisInterface.getStack());
         this.Essentia_StorageMonitor = new ThEItemDescription(AEPartsEnum.EssentiaStorageMonitor.getStack());
         this.Essentia_ConversionMonitor = new ThEItemDescription(AEPartsEnum.EssentiaConversionMonitor.getStack());
+        this.CreativeVisRelay_Interface = new ThEItemDescription(AEPartsEnum.CreativeVisInterface.getStack());
     }
 }


### PR DESCRIPTION
This was an oversight on how parts are generated. The part item damage is indexed off of the AEPartsEnum file. The CreativeVisInterface was put in the middle of this enum, so some essentia monitors got converted to vis relays. This has been reverted so that the CreativeVisInterface is placed last. Hopefully not too much damage was already done.

Also fixed the ItemStack used to generate the part. Changed from vis relay to creative vis relay so it doesnt lose its creative property on world save.