### PR TITLE
Allow the Provider to request essentia

### DIFF
--- a/src/main/java/thaumicenergistics/common/tiles/TileEssentiaProvider.java
+++ b/src/main/java/thaumicenergistics/common/tiles/TileEssentiaProvider.java
@@ -149,6 +149,14 @@ public class TileEssentiaProvider extends TileProviderBase implements IEssentiaT
         return 0;
     }
 
+    public int takeEssentiaOrder(Aspect aspect, int amount) {
+        long aspectAmountInNetwork = this.getAspectAmountInNetwork(aspect);
+        if (aspectAmountInNetwork < amount) {
+            this.orderSomeEssentia(aspect, (int)(aspectAmountInNetwork - amount));
+        }
+        return (int) aspectAmountInNetwork;
+    }
+
     @Override
     public Aspect getEssentiaType(final ForgeDirection side) {
         // Get the aspect this neighbor wants


### PR DESCRIPTION
Simple enough, does what it says, adds a new method that lets blocks request to see the if the essentia in the network is large enough for the operation, creates more if not, and returns the amount currently there.