### PR TITLE
Patch waila infusion provider

### DIFF
--- a/src/main/java/thaumicenergistics/common/blocks/BlockAdvancedInfusionProvider.java
+++ b/src/main/java/thaumicenergistics/common/blocks/BlockAdvancedInfusionProvider.java
@@ -47,7 +47,7 @@ public class BlockAdvancedInfusionProvider extends AbstractBlockProviderBase {
             final EntityPlayer player) {
         if (world.getTileEntity(x, y, z) instanceof TileAdvancedInfusionProvider taip && taip.isActive()) {
             if (!taip.matrices.isEmpty()) {
-                taip.unbindMatrixs();
+                taip.unbindMatrices();
             }
             taip.searchMatrix();
             return true;

--- a/src/main/java/thaumicenergistics/common/tiles/TileAdvancedInfusionProvider.java
+++ b/src/main/java/thaumicenergistics/common/tiles/TileAdvancedInfusionProvider.java
@@ -154,7 +154,7 @@ public class TileAdvancedInfusionProvider extends TileInfusionProvider implement
 
         if (!this.matrices.isEmpty() && this.isActive) {
             for (TileInfusionMatrix matrix : this.matrices) {
-                if (matrix == null) {
+                if (matrix == null || matrix.getWorldObj().isAirBlock(matrix.xCoord, matrix.yCoord, matrix.zCoord)) {
                     this.matricesToRemove.add(matrix);
                 } else {
                     this.grabAllAspects(matrix);

--- a/src/main/java/thaumicenergistics/common/tiles/TileAdvancedInfusionProvider.java
+++ b/src/main/java/thaumicenergistics/common/tiles/TileAdvancedInfusionProvider.java
@@ -78,7 +78,7 @@ public class TileAdvancedInfusionProvider extends TileInfusionProvider implement
         for (int dx = -HORIZONTAL_RADIUS; dx <= HORIZONTAL_RADIUS; dx++) {
             for (int dy = -VERTICAL_RADIUS; dy <= VERTICAL_RADIUS; dy++) {
                 if (dx == 0 && dy == 0 && currentZ == 0) continue;
-                this.bindMatrixs(this.xCoord + dx, this.yCoord + dy, this.zCoord + this.currentZ);
+                this.bindMatrices(this.xCoord + dx, this.yCoord + dy, this.zCoord + this.currentZ);
             }
         }
 
@@ -87,7 +87,7 @@ public class TileAdvancedInfusionProvider extends TileInfusionProvider implement
         }
     }
 
-    public void bindMatrixs(final int x, final int y, final int z) {
+    public void bindMatrices(final int x, final int y, final int z) {
         if (this.worldObj != null && this.worldObj.getTileEntity(x, y, z) instanceof TileInfusionMatrix tim) {
             if (this.matrices.contains(tim)) return;
             this.matrices.add(tim);
@@ -97,7 +97,7 @@ public class TileAdvancedInfusionProvider extends TileInfusionProvider implement
         }
     }
 
-    public void unbindMatrixs() {
+    public void unbindMatrices() {
         this.matrices.clear();
 
         this.markForUpdate();

--- a/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
@@ -82,7 +82,7 @@ thaumicenergistics.tooltip.button.reset.aspect.description=Reset the left-hand a
 thaumicenergistics.tooltip.advanced.infusion.provider.working.on=Workig Mode
 thaumicenergistics.tooltip.advanced.infusion.provider.normal=Normal Provider
 thaumicenergistics.tooltip.advanced.infusion.provider.advanced=Advanced Provider
-thaumicenergistics.tooltip.advanced.infusion.provider.totalbind=Total binded to %d matrixs
+thaumicenergistics.tooltip.advanced.infusion.provider.totalbind=Total binded to %d matrices
 
 
 #GUI


### PR DESCRIPTION
Correct the spelling of "Matrixs" by "Matrices".

Regarding incorrect counting, the block removes matrices only when right-clicking it. So, right-clicking the Infusion Provider will fix the amount. But I added an extra check, so it won't be needed any more.

**Warning:** The check for invalid matrices is done by checking world blocks being empty. If this check is not great and something lighter is required, it should be changed to some event handler on block break ? (I'm not sure how to do it, so for now i'll apply it this way).

Close GTNewHorizons/GT-New-Horizons-Modpack#17941