### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicenergistics/lang/en_US.lang
@@ -18,6 +18,7 @@ thaumicenergistics.block.essentia.vibration.chamber.name=Essentia Vibration Cham
 thaumicenergistics.block.distillation.encoder.name=Distillation Pattern Encoder
 
 #Cable parts
+thaumicenergistics.item.aeparts.name=Essentia Bus/Terminal/Interface/Monitor
 thaumicenergistics.aeparts.essentia.ImportBus.name=Essentia Import Bus
 thaumicenergistics.aeparts.essentia.ExportBus.name=Essentia Export Bus
 thaumicenergistics.aeparts.essentia.levelemitter.name=Essentia Level Emitter
@@ -30,6 +31,8 @@ thaumicenergistics.aeparts.essentia.storage.monitor.name=Essentia Storage Monito
 thaumicenergistics.aeparts.essentia.conversion.monitor.name=Essentia Conversion Monitor
 
 #Items
+item.itemCraftingAspect.name=Aspect
+thaumicenergistics.item.essentia.cell.name=ME Essentia Storage Cell
 thaumicenergistics.item.essentia.cell.1k.name=1k ME Essentia Storage Cell
 thaumicenergistics.item.essentia.cell.4k.name=4k ME Essentia Storage Cell
 thaumicenergistics.item.essentia.cell.16k.name=16k ME Essentia Storage Cell
@@ -42,6 +45,7 @@ thaumicenergistics.item.essentia.cell.quantum.name=ME Essentia Quantum Storage C
 thaumicenergistics.item.essentia.cell.singularity.name=ME Essentia Digital Singularity Storage Cell
 thaumicenergistics.item.essentia.cell.creative.name=Thaumometric Essentia Cell
 thaumicenergistics.item.storage.casing.name=ME Essentia Storage Housing
+thaumicenergistics.item.storage.component.name=ME Essentia Storage Component
 thaumicenergistics.item.storage.component.1k.name=1k ME Essentia Storage Component
 thaumicenergistics.item.storage.component.4k.name=4k ME Essentia Storage Component
 thaumicenergistics.item.storage.component.16k.name=16k ME Essentia Storage Component
@@ -50,6 +54,7 @@ thaumicenergistics.item.storage.component.256k.name=256k ME Essentia Storage Com
 thaumicenergistics.item.storage.component.1024k.name=1024k ME Essentia Storage Component
 thaumicenergistics.item.storage.component.4096k.name=4096k ME Essentia Storage Component
 thaumicenergistics.item.storage.component.16384k.name=16384k ME Essentia Storage Component
+thaumicenergistics.item.material.name=Material
 thaumicenergistics.item.material.diffusion.core.name=Diffusion Core
 thaumicenergistics.item.material.coalescence.core.name=Coalescence Core
 thaumicenergistics.item.material.iron.gear.name=Iron Gear


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.