### PR TITLE
Npe fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,20 +1,20 @@
 // Add your dependencies here
 
 dependencies {
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.64-GTNH:dev")
-    implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.3:dev")
-    implementation("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-658-GTNH:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.80-GTNH:dev")
+    implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev")
+    implementation("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-683-GTNH:dev")
     implementation("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     implementation("curse.maven:thaumcraft-nei-plugin-225095:2241913") { transitive = false }
 
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.35:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.100-gtnh:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.112-gtnh:dev') { transitive = false }
     compileOnly("com.github.GTNewHorizons:waila:1.8.12:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.390:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.446:dev") { transitive = false }
     compileOnly("curse.maven:computercraft-67504:2269339") { transitive = false }
     compileOnly("curse.maven:cofh-lib-220333:2388748") { transitive = false }
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") { transitive = false }
 
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:GTNHLib:0.6.38:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:GTNHLib:0.6.39:dev')
     runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 }

--- a/src/main/java/thaumicenergistics/common/container/slot/SlotArcaneCraftingResult.java
+++ b/src/main/java/thaumicenergistics/common/container/slot/SlotArcaneCraftingResult.java
@@ -117,28 +117,16 @@ public class SlotArcaneCraftingResult extends SlotCrafting {
                 continue;
             }
 
-            // Checked at the end to see if we need to decrement the slot
-            boolean shouldDecrement = true;
-
+            // Get the container item
+            ItemStack slotContainerStack = slotStack.getItem().getContainerItem(slotStack);
             // Does the item have a container?
-            if (slotStack.getItem().hasContainerItem(slotStack)) {
-                // Get the container item
-                ItemStack slotContainerStack = slotStack.getItem().getContainerItem(slotStack);
+            if (slotContainerStack != null) {
 
-                // Is the container item damage-able?
-                if (slotContainerStack.isItemStackDamageable()) {
-                    // Did we kill it?
-                    if (slotContainerStack.getItemDamage() >= slotContainerStack.getMaxDamage()) {
-                        // Fire forge event
-                        MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, slotContainerStack));
-
-                        // Null the container stack
-                        slotContainerStack = null;
-                    }
-                }
-
-                // Did we not kill the container item?
-                if (slotContainerStack != null) {
+                if (slotContainerStack.isItemStackDamageable()
+                        && slotContainerStack.getItemDamage() >= slotContainerStack.getMaxDamage()) {
+                    MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, slotContainerStack));
+                } else {
+                    // Did we not kill the container item?
                     /*
                      * Should the item stay in the crafting grid, or if it is supposed to go back to the players
                      * inventory but can't?
@@ -147,15 +135,13 @@ public class SlotArcaneCraftingResult extends SlotCrafting {
                             || !player.inventory.addItemStackToInventory(slotContainerStack)) {
                         // Place it back in the grid
                         this.terminalInventory.setInventorySlotContents(slotIndex, slotContainerStack);
-
-                        // Set NOT to decrement
-                        shouldDecrement = false;
+                        return;
                     }
                 }
             }
 
             // If decrementing it would result in it being empty, ask the ME system for a replenishment.
-            if (shouldDecrement && (slotStack.stackSize == 1)) {
+            if (slotStack.stackSize == 1) {
                 // First check if we can replenish it from the ME network
                 ItemStack replenishment = this.hostContianer.requestCraftingReplenishment(slotStack);
 
@@ -166,16 +152,12 @@ public class SlotArcaneCraftingResult extends SlotCrafting {
                         // Set the slot contents to the replenishment
                         this.terminalInventory.setInventorySlotContents(slotIndex, replenishment);
                     }
-
-                    // And mark not to decrement
-                    shouldDecrement = false;
+                    return;
                 }
             }
 
-            // Decrement the stack?
-            if (shouldDecrement) {
-                this.terminalInventory.decrStackSize(slotIndex, 1);
-            }
+            // Decrement the stack
+            this.terminalInventory.decrStackSize(slotIndex, 1);
         }
     }
 

--- a/src/main/java/thaumicenergistics/common/container/slot/SlotArcaneCraftingResult.java
+++ b/src/main/java/thaumicenergistics/common/container/slot/SlotArcaneCraftingResult.java
@@ -135,7 +135,7 @@ public class SlotArcaneCraftingResult extends SlotCrafting {
                             || !player.inventory.addItemStackToInventory(slotContainerStack)) {
                         // Place it back in the grid
                         this.terminalInventory.setInventorySlotContents(slotIndex, slotContainerStack);
-                        return;
+                        continue;
                     }
                 }
             }
@@ -152,7 +152,7 @@ public class SlotArcaneCraftingResult extends SlotCrafting {
                         // Set the slot contents to the replenishment
                         this.terminalInventory.setInventorySlotContents(slotIndex, replenishment);
                     }
-                    return;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
Saw a few people in general who told me that the game crashes if you try to craft an item with a tool that has a durability of 1. This pr fixes it. 

Though this doesn't fix the root cause. Root cause is because of https://github.com/GTNewHorizons/GT5-Unofficial/pull/4383, which added the possibility that hasContainerItem returns true while getContainerItem returns null (if the item would break next craft).