### PR TITLE
Add legacy support for essentia level emitter type filters

### DIFF
--- a/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
@@ -9,10 +9,10 @@ import appeng.api.storage.StorageName;
 import appeng.api.storage.data.IAEStackType;
 import appeng.parts.automation.PartLevelEmitter;
 import appeng.util.LevelEmitterTypeFilter;
+import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
 import thaumcraft.api.aspects.Aspect;
 import thaumicenergistics.common.storage.AEEssentiaStack;
 import thaumicenergistics.common.storage.AEEssentiaStackType;
-import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
 
 public class PartEssentiaLevelEmitter extends PartLevelEmitter {
 

--- a/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
+++ b/src/main/java/thaumicenergistics/common/parts/PartEssentiaLevelEmitter.java
@@ -6,9 +6,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.Settings;
 import appeng.api.storage.StorageName;
+import appeng.api.storage.data.IAEStackType;
 import appeng.parts.automation.PartLevelEmitter;
+import appeng.util.LevelEmitterTypeFilter;
 import thaumcraft.api.aspects.Aspect;
 import thaumicenergistics.common.storage.AEEssentiaStack;
+import thaumicenergistics.common.storage.AEEssentiaStackType;
+import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
 
 public class PartEssentiaLevelEmitter extends PartLevelEmitter {
 
@@ -38,6 +42,15 @@ public class PartEssentiaLevelEmitter extends PartLevelEmitter {
 
         if (data.hasKey(NBT_KEY_WANTED_AMOUNT)) {
             this.setReportingValue(data.getLong(NBT_KEY_WANTED_AMOUNT));
+        }
+
+        // Legacy essentia level emitter (placed before unified toggle): essentia only, item and fluid off
+        if (!data.hasKey(LevelEmitterTypeFilter.NBT_FILTERS) && !data.hasKey("TYPE_FILTER")) {
+            final Reference2BooleanMap<IAEStackType<?>> filters = this.getTypeFilters().getFilters();
+            for (IAEStackType<?> type : filters.keySet()) {
+                filters.put(type, type == AEEssentiaStackType.ESSENTIA_STACK_TYPE);
+            }
+            this.saveChanges();
         }
     }
 


### PR DESCRIPTION
Don't merge without [1137](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/1137)
Don't merge without [413](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/413)

This update introduces handling for legacy essentia level emitters by setting default type filters when no specific filters are defined. This ensures compatibility with previously placed emitters that do not utilize the unified toggle system.