### PR TITLE
Fix Arcane Crafting Terminal Transfer Item BUG

### DIFF
--- a/src/main/java/thaumicenergistics/client/gui/GuiArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/client/gui/GuiArcaneCraftingTerminal.java
@@ -169,7 +169,9 @@ public class GuiArcaneCraftingTerminal extends GuiMEMonitorable {
             if (slot.getStack() == null) return;
 
             InventoryAction action;
-            if (isShiftKeyDown()) {
+            if (isCtrlKeyDown()) {
+                action = InventoryAction.CRAFT_STACK;
+            } else if (isShiftKeyDown()) {
                 action = InventoryAction.CRAFT_SHIFT;
             } else {
                 action = InventoryAction.CRAFT_ITEM;

--- a/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
@@ -140,6 +140,9 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
         if (action == InventoryAction.CRAFT_ITEM) {
             this.craftOnce(player);
             return;
+        } else if (action == InventoryAction.CRAFT_STACK) {
+            this.craftStackToHand(player);
+            return;
         } else if (action == InventoryAction.CRAFT_SHIFT) {
             this.craftStack(player);
             return;
@@ -362,6 +365,34 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
     private void craftStack(EntityPlayer player) {
         if (this.resultSlot.getStack() == null) return;
         InventoryAdaptor adaptor = InventoryAdaptor.getAdaptor(player, null);
+        int maxTimesToCraft = this.calculateMaxTimesToCraft(adaptor);
+        if (maxTimesToCraft == 0) return;
+
+        for (int i = 0; i < maxTimesToCraft; i++) {
+            adaptor.addItems(this.resultSlot.getStack());
+            this.consumeIngredients(player);
+            if (this.resultSlot.getStack() == null) break;
+        }
+
+        this.detectAndSendChanges();
+    }
+
+    private void craftStackToHand(EntityPlayer player) {
+        if (this.resultSlot.getStack() == null) return;
+        AdaptorPlayerHand adaptor = new AdaptorPlayerHand(player);
+        int maxTimesToCraft = this.calculateMaxTimesToCraft(adaptor);
+        if (maxTimesToCraft == 0) return;
+
+        for (int i = 0; i < maxTimesToCraft; i++) {
+            adaptor.addItems(this.resultSlot.getStack());
+            this.consumeIngredients(player);
+            if (this.resultSlot.getStack() == null) break;
+        }
+
+        this.detectAndSendChanges();
+    }
+
+    private int calculateMaxTimesToCraft(InventoryAdaptor adaptor) {
         int maxTimesToCraft = (int) Math.floor(
                 (double) this.resultSlot.getStack().getMaxStackSize() / (double) this.resultSlot.getStack().stackSize);
 
@@ -373,15 +404,7 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
                     .floor((double) simResult.stackSize / (double) this.resultSlot.getStack().stackSize);
         }
 
-        if (maxTimesToCraft == 0) return;
-
-        for (int i = 0; i < maxTimesToCraft; i++) {
-            adaptor.addItems(this.resultSlot.getStack());
-            this.consumeIngredients(player);
-            if (this.resultSlot.getStack() == null) break;
-        }
-
-        this.detectAndSendChanges();
+        return maxTimesToCraft;
     }
 
     public void consumeIngredients(final EntityPlayer player) {

--- a/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
@@ -347,6 +347,7 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
     }
 
     private void craftOnce(EntityPlayerMP player) {
+        if (this.resultSlot.getStack() == null) return;
         AdaptorPlayerHand adaptor = new AdaptorPlayerHand(player);
         ItemStack leftover = adaptor.simulateAdd(this.resultSlot.getStack());
         if (leftover != null) return;
@@ -359,6 +360,7 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
     }
 
     private void craftStack(EntityPlayer player) {
+        if (this.resultSlot.getStack() == null) return;
         InventoryAdaptor adaptor = InventoryAdaptor.getAdaptor(player, null);
         int maxTimesToCraft = (int) Math.floor(
                 (double) this.resultSlot.getStack().getMaxStackSize() / (double) this.resultSlot.getStack().stackSize);
@@ -383,10 +385,12 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
     }
 
     public void consumeIngredients(final EntityPlayer player) {
+        ItemStack craftResult = this.resultSlot.getStack();
+        if (craftResult == null) return;
         MinecraftForge.EVENT_BUS.post(
                 new PlayerEvent.ItemCraftedEvent(
                         player,
-                        this.resultSlot.getStack(),
+                        craftResult,
                         this.terminal.craftingGridInventory));
         if (player.worldObj.isRemote) return;
 

--- a/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
+++ b/src/main/java/thaumicenergistics/common/container/ContainerPartArcaneCraftingTerminal.java
@@ -387,11 +387,8 @@ public class ContainerPartArcaneCraftingTerminal extends ContainerMEMonitorable 
     public void consumeIngredients(final EntityPlayer player) {
         ItemStack craftResult = this.resultSlot.getStack();
         if (craftResult == null) return;
-        MinecraftForge.EVENT_BUS.post(
-                new PlayerEvent.ItemCraftedEvent(
-                        player,
-                        craftResult,
-                        this.terminal.craftingGridInventory));
+        MinecraftForge.EVENT_BUS
+                .post(new PlayerEvent.ItemCraftedEvent(player, craftResult, this.terminal.craftingGridInventory));
         if (player.worldObj.isRemote) return;
 
         if ((this.requiredAspects != null)) {

--- a/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
+++ b/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
@@ -81,6 +81,8 @@ public class Packet_S_NEIRecipe extends ThEServerPacket {
      */
     @Override
     public void execute() {
+        if (this.recipe == null) return;
+
         final EntityPlayerMP pmp = (EntityPlayerMP) player;
         final Container con = pmp.openContainer;
 
@@ -163,6 +165,27 @@ public class Packet_S_NEIRecipe extends ThEServerPacket {
                                         all,
                                         Actionable.MODULATE,
                                         filter);
+                        if (whichItem == null && this.recipe[x] != null) {
+                            for (int y = 0; y < this.recipe[x].length; y++) {
+                                if (this.recipe[x][y] == null) continue;
+                                final IAEItemStack request = AEItemStack.create(this.recipe[x][y]);
+                                if (request != null) {
+                                    request.setStackSize(1);
+                                    if (filter == null || filter.isListed(request)) {
+                                        final IAEItemStack out = Platform.poweredExtraction(
+                                                energy,
+                                                storage,
+                                                request,
+                                                as);
+                                        if (out != null) {
+                                            whichItem = out.getItemStack();
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         if (whichItem == null && playerInventory != null)
                             whichItem = extractItemFromPlayerInventory(player, patternItem);
 

--- a/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
+++ b/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
@@ -172,11 +172,8 @@ public class Packet_S_NEIRecipe extends ThEServerPacket {
                                 if (request != null) {
                                     request.setStackSize(1);
                                     if (filter == null || filter.isListed(request)) {
-                                        final IAEItemStack out = Platform.poweredExtraction(
-                                                energy,
-                                                storage,
-                                                request,
-                                                as);
+                                        final IAEItemStack out = Platform
+                                                .poweredExtraction(energy, storage, request, as);
                                         if (out != null) {
                                             whichItem = out.getItemStack();
                                             break;

--- a/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
+++ b/src/main/java/thaumicenergistics/common/network/packet/server/Packet_S_NEIRecipe.java
@@ -167,8 +167,18 @@ public class Packet_S_NEIRecipe extends ThEServerPacket {
                                         filter);
                         if (whichItem == null && this.recipe[x] != null) {
                             for (int y = 0; y < this.recipe[x].length; y++) {
-                                if (this.recipe[x][y] == null) continue;
-                                final IAEItemStack request = AEItemStack.create(this.recipe[x][y]);
+                                final ItemStack candidate = this.recipe[x][y];
+                                if (candidate == null || !this.isCandidateValidForSlot(
+                                        r,
+                                        arcaneRecipe,
+                                        testInv,
+                                        workbenchTile,
+                                        pmp,
+                                        x,
+                                        candidate,
+                                        is))
+                                    continue;
+                                final IAEItemStack request = AEItemStack.create(candidate);
                                 if (request != null) {
                                     request.setStackSize(1);
                                     if (filter == null || filter.isListed(request)) {
@@ -259,5 +269,26 @@ public class Packet_S_NEIRecipe extends ThEServerPacket {
                 || patternItem.isItemStackDamageable();
         return checkFuzzy ? ia.removeSimilarItems(1, patternItem, FuzzyMode.IGNORE_ALL, null)
                 : ia.removeItems(1, patternItem, null);
+    }
+
+    private boolean isCandidateValidForSlot(final IRecipe recipe, final IArcaneRecipe arcaneRecipe,
+            final InventoryCrafting testInv, final TileMagicWorkbench workbenchTile, final EntityPlayerMP player,
+            final int slotIndex, final ItemStack candidate, final ItemStack expectedOutput) {
+        final ItemStack originalTestSlot = testInv.getStackInSlot(slotIndex);
+        final ItemStack originalWorkbenchSlot = workbenchTile.getStackInSlot(slotIndex);
+
+        testInv.setInventorySlotContents(slotIndex, candidate);
+        workbenchTile.setInventorySlotContents(slotIndex, candidate);
+
+        final ItemStack candidateResult = recipe != null
+                ? (recipe.matches(testInv, player.worldObj) ? recipe.getCraftingResult(testInv) : null)
+                : (arcaneRecipe.matches(workbenchTile, player.worldObj, player)
+                        ? arcaneRecipe.getCraftingResult(workbenchTile)
+                        : null);
+
+        testInv.setInventorySlotContents(slotIndex, originalTestSlot);
+        workbenchTile.setInventorySlotContents(slotIndex, originalWorkbenchSlot);
+
+        return candidateResult != null && Platform.isSameItemPrecise(candidateResult, expectedOutput);
     }
 }


### PR DESCRIPTION
Fixed Arcane Crafting Terminal tranfer item failed bug
Now AE can correctly extract item to crafting slots

new fixes:  Fix ACT ctrl crafting behavior and arcane NEI crystal slot filling
added ctrl auto crafting function(like original ae terminal)