### PR TITLE
Fix crash with EndlessIds

### DIFF
--- a/src/main/java/thaumicenergistics/common/integration/tc/GolemHooks.java
+++ b/src/main/java/thaumicenergistics/common/integration/tc/GolemHooks.java
@@ -287,7 +287,7 @@ public class GolemHooks {
             for (int i = 4; i < 31; ++i) {
                 try {
                     // Add the object
-                    watcher.addObject(GolemHooks.DATAWATCHER_ID, localRegistry.mappingsToString());
+                    watcher.addObject(i, localRegistry.mappingsToString());
 
                     // Object was added
                     GolemHooks.DATAWATCHER_ID = i;


### PR DESCRIPTION
There is a bug  in this mod which silently did nothing for 10 years until EndlessIds revealed it.

The  fix is trivially correct, since the original loop didn't actually work and -1 isn't a valid ID for a watched object.

All these interactions result in null watcher objects in the DataWater's watchedObjects list, which crashes the client.

For future reference, this is the type of issue linked with a stack trace such as:
```

[18:49:05] [Client thread/ERROR] [FML]: A severe problem occurred during the spawning of an entity at ( -2026.21875,109.0, -1977.65625)
java.lang.NullPointerException: Cannot invoke "net.minecraft.entity.DataWatcher$WatchableObject.func_75672_a()" because "<local3>" is null
	at Launch//net.minecraft.entity.DataWatcher.func_75687_a(SourceFile:303) ~[te.class:?]
	at Launch//cpw.mods.fml.common.network.internal.EntitySpawnHandler.spawnEntity(EntitySpawnHandler.java:110) [EntitySpawnHandler.class:?]
	at Launch//cpw.mods.fml.common.network.internal.EntitySpawnHandler.channelRead0(EntitySpawnHandler.java:34) [EntitySpawnHandler.class:?]
	at Launch//cpw.mods.fml.common.network.internal.EntitySpawnHandler.channelRead0(EntitySpawnHandler.java:28) [EntitySpawnHandler.class:?]
	at Launch//io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) [netty-all-4.0.10.Final.jar:?]
	at Launch//cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77) [FMLProxyPacket.class:?]
	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) [ej.class:?]
	at Launch//net.minecraft.client.multiplayer.PlayerControllerMP.func_78765_e(PlayerControllerMP.java:273) [bje.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1602) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:9110) [bao.class:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) [Launch.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) [lwjgl3ify-3.0.16-forgePatches.jar:3.0.16]
	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47) [lwjgl3ify-3.0.16-forgePatches.jar:3.0.16]
	at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]
```